### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pygments/lexer.py
+++ b/pygments/lexer.py
@@ -505,7 +505,7 @@ class RegexLexer(Lexer):
         """
         Split ``text`` into (tokentype, text) pairs.
 
-        ``stack`` is the inital stack (default: ``['root']``)
+        ``stack`` is the initial stack (default: ``['root']``)
         """
         pos = 0
         tokendefs = self._tokens

--- a/pygments/lexers/compiled.py
+++ b/pygments/lexers/compiled.py
@@ -879,7 +879,7 @@ class DelphiLexer(Lexer):
                     # abort function naming ``foo = Function(...)``
                     next_token_is_function = False
                     # if we are in a function block we count the open
-                    # braces because ootherwise it's impossible to
+                    # braces because otherwise it's impossible to
                     # determine the end of the modifier context
                     if in_function_block or in_property_block:
                         if scanner.match == '(':
@@ -897,7 +897,7 @@ class DelphiLexer(Lexer):
                     elif lowercase_name in self.keywords:
                         token = Keyword
                         # if we are in a special block and a
-                        # block ending keyword occours (and the parenthesis
+                        # block ending keyword occurs (and the parenthesis
                         # is balanced) we end the current block context
                         if (in_function_block or in_property_block) and \
                            lowercase_name in self.BLOCK_KEYWORDS and \

--- a/pygments/lexers/dotnet.py
+++ b/pygments/lexers/dotnet.py
@@ -492,7 +492,7 @@ class GenericAspxLexer(RegexLexer):
 #TODO support multiple languages within the same source file
 class CSharpAspxLexer(DelegatingLexer):
     """
-    Lexer for highligting C# within ASP.NET pages.
+    Lexer for highlighting C# within ASP.NET pages.
     """
 
     name = 'aspx-cs'
@@ -513,7 +513,7 @@ class CSharpAspxLexer(DelegatingLexer):
 
 class VbNetAspxLexer(DelegatingLexer):
     """
-    Lexer for highligting Visual Basic.net within ASP.NET pages.
+    Lexer for highlighting Visual Basic.net within ASP.NET pages.
     """
 
     name = 'aspx-vb'

--- a/pygments/lexers/other.py
+++ b/pygments/lexers/other.py
@@ -2691,9 +2691,9 @@ class UrbiscriptLexer(ExtendedRegexLexer):
              r'signed|sizeof|static_cast|struct|template|typedef|typeid|'
              r'typename|union|unsigned|using|virtual|volatile|'
              r'wchar_t)\b', Keyword.Reserved),
-            # deprecated keywords, use a meaningfull token when available
+            # deprecated keywords, use a meaningful token when available
             (r'(?:emit|foreach|internal|loopn|static)\b', Keyword),
-            # ignored keywords, use a meaningfull token when available
+            # ignored keywords, use a meaningful token when available
             (r'(?:private|protected|public)\b', Keyword),
             (r'(?:var|do|const|function|class)\b', Keyword.Declaration),
             (r'(?:true|false|nil|void)\b', Keyword.Constant),

--- a/pygments/lexers/templates.py
+++ b/pygments/lexers/templates.py
@@ -1164,7 +1164,7 @@ class JavascriptPhpLexer(DelegatingLexer):
 
 class HtmlSmartyLexer(DelegatingLexer):
     """
-    Subclass of the `SmartyLexer` that highighlights unlexed data with the
+    Subclass of the `SmartyLexer` that highlights unlexed data with the
     `HtmlLexer`.
 
     Nested Javascript and CSS is highlighted too.
@@ -1247,7 +1247,7 @@ class JavascriptSmartyLexer(DelegatingLexer):
 
 class HtmlDjangoLexer(DelegatingLexer):
     """
-    Subclass of the `DjangoLexer` that highighlights unlexed data with the
+    Subclass of the `DjangoLexer` that highlights unlexed data with the
     `HtmlLexer`.
 
     Nested Javascript and CSS is highlighted too.

--- a/pygments/lexers/web.py
+++ b/pygments/lexers/web.py
@@ -149,7 +149,7 @@ class JSONLexer(RegexLexer):
         ],
 
 
-        # the root of a json document whould be a value
+        # the root of a json document would be a value
         'root': [
             include('value'),
         ],


### PR DESCRIPTION
There are small typos in:
- pygments/lexer.py
- pygments/lexers/compiled.py
- pygments/lexers/dotnet.py
- pygments/lexers/other.py
- pygments/lexers/templates.py
- pygments/lexers/web.py

Fixes:
- Should read `meaningful` rather than `meaningfull`.
- Should read `highlights` rather than `highighlights`.
- Should read `highlighting` rather than `highligting`.
- Should read `would` rather than `whould`.
- Should read `otherwise` rather than `ootherwise`.
- Should read `occurs` rather than `occours`.
- Should read `initial` rather than `inital`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md